### PR TITLE
Aurora 475 Remove Copyright Apache Software Foundation from the source files license header

### DIFF
--- a/3rdparty/javascript/thrift.js
+++ b/3rdparty/javascript/thrift.js
@@ -1,5 +1,4 @@
 /*
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/3rdparty/python/BUILD
+++ b/3rdparty/python/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,6 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2013 Apache Software Foundation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build-support/hooks/pre-commit
+++ b/build-support/hooks/pre-commit
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build-support/isort
+++ b/build-support/isort
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build-support/isort-check
+++ b/build-support/isort-check
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build-support/isort-run
+++ b/build-support/isort-run
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build-support/jenkins/build.sh
+++ b/build-support/jenkins/build.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build-support/pex
+++ b/build-support/pex
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build-support/release/changelog
+++ b/build-support/release/changelog
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build-support/release/make-python-sdists
+++ b/build-support/release/make-python-sdists
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build-support/release/release
+++ b/build-support/release/release
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build-support/release/release-candidate
+++ b/build-support/release/release-candidate
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build-support/release/verify-release-candidate
+++ b/build-support/release/verify-release-candidate
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build-support/thrift/Makefile
+++ b/build-support/thrift/Makefile
@@ -1,4 +1,3 @@
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build-support/tools/list-missing-shipits
+++ b/build-support/tools/list-missing-shipits
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 /*
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/checkstyle/apache.header
+++ b/config/checkstyle/apache.header
@@ -1,5 +1,3 @@
-Copyright ${year} Apache Software Foundation
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/config/checkstyle/apache.header.regex
+++ b/config/checkstyle/apache.header.regex
@@ -1,5 +1,4 @@
 ^\/\*\*$
-^ \* Copyright \d\d\d\d Apache Software Foundation$
 ^ \*$
 ^ \* Licensed under the Apache License, Version 2.0 \(the "License"\);$
 ^ \* you may not use this file except in compliance with the License.$

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0"?>
 <!--
-Copyright 2013 Apache Software Foundation
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this work except in compliance with the License.
 You may obtain a copy of the License in the LICENSE file, or at:

--- a/examples/scheduler/scheduler-local.sh
+++ b/examples/scheduler/scheduler-local.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/vagrant/provision-dev-cluster.sh
+++ b/examples/vagrant/provision-dev-cluster.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -x
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/vagrant/test_tutorial.sh
+++ b/examples/vagrant/test_tutorial.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/vagrant/upstart/aurora-scheduler.conf
+++ b/examples/vagrant/upstart/aurora-scheduler.conf
@@ -1,4 +1,3 @@
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/vagrant/upstart/aurora-thermos-observer.conf
+++ b/examples/vagrant/upstart/aurora-thermos-observer.conf
@@ -1,4 +1,3 @@
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/vagrant/upstart/mesos-master.conf
+++ b/examples/vagrant/upstart/mesos-master.conf
@@ -1,4 +1,3 @@
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/vagrant/upstart/mesos-slave.conf
+++ b/examples/vagrant/upstart/mesos-slave.conf
@@ -1,4 +1,3 @@
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/vagrant/upstart/zookeeper.conf
+++ b/examples/vagrant/upstart/zookeeper.conf
@@ -1,4 +1,3 @@
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gradlew
+++ b/gradlew
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants
+++ b/pants
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pants.ini
+++ b/pants.ini
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rbt
+++ b/rbt
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/GuiceUtils.java
+++ b/src/main/java/org/apache/aurora/GuiceUtils.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/Protobufs.java
+++ b/src/main/java/org/apache/aurora/Protobufs.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/auth/CapabilityValidator.java
+++ b/src/main/java/org/apache/aurora/auth/CapabilityValidator.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/auth/SessionValidator.java
+++ b/src/main/java/org/apache/aurora/auth/SessionValidator.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/auth/UnsecureAuthModule.java
+++ b/src/main/java/org/apache/aurora/auth/UnsecureAuthModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/codec/ThriftBinaryCodec.java
+++ b/src/main/java/org/apache/aurora/codec/ThriftBinaryCodec.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/Driver.java
+++ b/src/main/java/org/apache/aurora/scheduler/Driver.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/DriverFactory.java
+++ b/src/main/java/org/apache/aurora/scheduler/DriverFactory.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/MesosSchedulerImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/MesosSchedulerImpl.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/MesosTaskFactory.java
+++ b/src/main/java/org/apache/aurora/scheduler/MesosTaskFactory.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/ResourceSlot.java
+++ b/src/main/java/org/apache/aurora/scheduler/ResourceSlot.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/SchedulerLifecycle.java
+++ b/src/main/java/org/apache/aurora/scheduler/SchedulerLifecycle.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/SchedulerModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/SchedulerModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/TaskIdGenerator.java
+++ b/src/main/java/org/apache/aurora/scheduler/TaskIdGenerator.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/TaskLauncher.java
+++ b/src/main/java/org/apache/aurora/scheduler/TaskLauncher.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/TaskVars.java
+++ b/src/main/java/org/apache/aurora/scheduler/TaskVars.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/UserTaskLauncher.java
+++ b/src/main/java/org/apache/aurora/scheduler/UserTaskLauncher.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/app/AppModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/app/AppModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/app/Log4jConfigurator.java
+++ b/src/main/java/org/apache/aurora/scheduler/app/Log4jConfigurator.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/app/Modules.java
+++ b/src/main/java/org/apache/aurora/scheduler/app/Modules.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/app/SchedulerMain.java
+++ b/src/main/java/org/apache/aurora/scheduler/app/SchedulerMain.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/async/AsyncModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/async/AsyncModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/async/GcExecutorLauncher.java
+++ b/src/main/java/org/apache/aurora/scheduler/async/GcExecutorLauncher.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/async/HistoryPruner.java
+++ b/src/main/java/org/apache/aurora/scheduler/async/HistoryPruner.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/async/OfferQueue.java
+++ b/src/main/java/org/apache/aurora/scheduler/async/OfferQueue.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/async/Preemptor.java
+++ b/src/main/java/org/apache/aurora/scheduler/async/Preemptor.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/async/RescheduleCalculator.java
+++ b/src/main/java/org/apache/aurora/scheduler/async/RescheduleCalculator.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/async/TaskGroup.java
+++ b/src/main/java/org/apache/aurora/scheduler/async/TaskGroup.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/async/TaskGroups.java
+++ b/src/main/java/org/apache/aurora/scheduler/async/TaskGroups.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/async/TaskScheduler.java
+++ b/src/main/java/org/apache/aurora/scheduler/async/TaskScheduler.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/async/TaskThrottler.java
+++ b/src/main/java/org/apache/aurora/scheduler/async/TaskThrottler.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/async/TaskTimeout.java
+++ b/src/main/java/org/apache/aurora/scheduler/async/TaskTimeout.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/base/AsyncUtil.java
+++ b/src/main/java/org/apache/aurora/scheduler/base/AsyncUtil.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/base/CommandUtil.java
+++ b/src/main/java/org/apache/aurora/scheduler/base/CommandUtil.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/base/Conversions.java
+++ b/src/main/java/org/apache/aurora/scheduler/base/Conversions.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/base/JobKeys.java
+++ b/src/main/java/org/apache/aurora/scheduler/base/JobKeys.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/base/Jobs.java
+++ b/src/main/java/org/apache/aurora/scheduler/base/Jobs.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/base/Numbers.java
+++ b/src/main/java/org/apache/aurora/scheduler/base/Numbers.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/base/Query.java
+++ b/src/main/java/org/apache/aurora/scheduler/base/Query.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/base/ResourceAggregates.java
+++ b/src/main/java/org/apache/aurora/scheduler/base/ResourceAggregates.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/base/ScheduleException.java
+++ b/src/main/java/org/apache/aurora/scheduler/base/ScheduleException.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/base/SchedulerException.java
+++ b/src/main/java/org/apache/aurora/scheduler/base/SchedulerException.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/base/Tasks.java
+++ b/src/main/java/org/apache/aurora/scheduler/base/Tasks.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/configuration/ConfigurationManager.java
+++ b/src/main/java/org/apache/aurora/scheduler/configuration/ConfigurationManager.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/configuration/Resources.java
+++ b/src/main/java/org/apache/aurora/scheduler/configuration/Resources.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/configuration/SanitizedConfiguration.java
+++ b/src/main/java/org/apache/aurora/scheduler/configuration/SanitizedConfiguration.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/cron/CronException.java
+++ b/src/main/java/org/apache/aurora/scheduler/cron/CronException.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/cron/CronJobManager.java
+++ b/src/main/java/org/apache/aurora/scheduler/cron/CronJobManager.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/cron/CronPredictor.java
+++ b/src/main/java/org/apache/aurora/scheduler/cron/CronPredictor.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/cron/CronScheduler.java
+++ b/src/main/java/org/apache/aurora/scheduler/cron/CronScheduler.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/cron/CrontabEntry.java
+++ b/src/main/java/org/apache/aurora/scheduler/cron/CrontabEntry.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/cron/SanitizedCronJob.java
+++ b/src/main/java/org/apache/aurora/scheduler/cron/SanitizedCronJob.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/cron/quartz/AuroraCronJob.java
+++ b/src/main/java/org/apache/aurora/scheduler/cron/quartz/AuroraCronJob.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/cron/quartz/AuroraCronJobFactory.java
+++ b/src/main/java/org/apache/aurora/scheduler/cron/quartz/AuroraCronJobFactory.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/cron/quartz/CronJobManagerImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/cron/quartz/CronJobManagerImpl.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/cron/quartz/CronLifecycle.java
+++ b/src/main/java/org/apache/aurora/scheduler/cron/quartz/CronLifecycle.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/cron/quartz/CronModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/cron/quartz/CronModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/cron/quartz/CronPredictorImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/cron/quartz/CronPredictorImpl.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/cron/quartz/CronSchedulerImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/cron/quartz/CronSchedulerImpl.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/cron/quartz/Quartz.java
+++ b/src/main/java/org/apache/aurora/scheduler/cron/quartz/Quartz.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/events/EventSink.java
+++ b/src/main/java/org/apache/aurora/scheduler/events/EventSink.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/events/NotifyingSchedulingFilter.java
+++ b/src/main/java/org/apache/aurora/scheduler/events/NotifyingSchedulingFilter.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/events/PubsubEvent.java
+++ b/src/main/java/org/apache/aurora/scheduler/events/PubsubEvent.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/events/PubsubEventModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/events/PubsubEventModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/filter/AttributeAggregate.java
+++ b/src/main/java/org/apache/aurora/scheduler/filter/AttributeAggregate.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/filter/AttributeFilter.java
+++ b/src/main/java/org/apache/aurora/scheduler/filter/AttributeFilter.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/filter/ConstraintFilter.java
+++ b/src/main/java/org/apache/aurora/scheduler/filter/ConstraintFilter.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/filter/SchedulingFilter.java
+++ b/src/main/java/org/apache/aurora/scheduler/filter/SchedulingFilter.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/filter/SchedulingFilterImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/filter/SchedulingFilterImpl.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/http/Cron.java
+++ b/src/main/java/org/apache/aurora/scheduler/http/Cron.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/http/HttpStatsFilter.java
+++ b/src/main/java/org/apache/aurora/scheduler/http/HttpStatsFilter.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/http/JerseyTemplateServlet.java
+++ b/src/main/java/org/apache/aurora/scheduler/http/JerseyTemplateServlet.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/http/LeaderRedirect.java
+++ b/src/main/java/org/apache/aurora/scheduler/http/LeaderRedirect.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/http/LeaderRedirectFilter.java
+++ b/src/main/java/org/apache/aurora/scheduler/http/LeaderRedirectFilter.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/http/Maintenance.java
+++ b/src/main/java/org/apache/aurora/scheduler/http/Maintenance.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/http/Mname.java
+++ b/src/main/java/org/apache/aurora/scheduler/http/Mname.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/http/Offers.java
+++ b/src/main/java/org/apache/aurora/scheduler/http/Offers.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/http/PendingTasks.java
+++ b/src/main/java/org/apache/aurora/scheduler/http/PendingTasks.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/http/Quotas.java
+++ b/src/main/java/org/apache/aurora/scheduler/http/Quotas.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/http/ServletModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/http/ServletModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/http/Slaves.java
+++ b/src/main/java/org/apache/aurora/scheduler/http/Slaves.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/http/StructDump.java
+++ b/src/main/java/org/apache/aurora/scheduler/http/StructDump.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/http/TransformationUtils.java
+++ b/src/main/java/org/apache/aurora/scheduler/http/TransformationUtils.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/http/Utilization.java
+++ b/src/main/java/org/apache/aurora/scheduler/http/Utilization.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/local/FakeDriverFactory.java
+++ b/src/main/java/org/apache/aurora/scheduler/local/FakeDriverFactory.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/local/IsolatedSchedulerModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/local/IsolatedSchedulerModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/log/Log.java
+++ b/src/main/java/org/apache/aurora/scheduler/log/Log.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/log/mesos/LogInterface.java
+++ b/src/main/java/org/apache/aurora/scheduler/log/mesos/LogInterface.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/log/mesos/MesosLog.java
+++ b/src/main/java/org/apache/aurora/scheduler/log/mesos/MesosLog.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/log/mesos/MesosLogStreamModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/log/mesos/MesosLogStreamModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/log/testing/FileLog.java
+++ b/src/main/java/org/apache/aurora/scheduler/log/testing/FileLog.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/log/testing/FileLogStreamModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/log/testing/FileLogStreamModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/metadata/MetadataModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/metadata/MetadataModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/metadata/NearestFit.java
+++ b/src/main/java/org/apache/aurora/scheduler/metadata/NearestFit.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/quota/QuotaCheckResult.java
+++ b/src/main/java/org/apache/aurora/scheduler/quota/QuotaCheckResult.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/quota/QuotaInfo.java
+++ b/src/main/java/org/apache/aurora/scheduler/quota/QuotaInfo.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/quota/QuotaManager.java
+++ b/src/main/java/org/apache/aurora/scheduler/quota/QuotaManager.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/quota/QuotaModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/quota/QuotaModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/sla/MetricCalculator.java
+++ b/src/main/java/org/apache/aurora/scheduler/sla/MetricCalculator.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/sla/SlaAlgorithm.java
+++ b/src/main/java/org/apache/aurora/scheduler/sla/SlaAlgorithm.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/sla/SlaGroup.java
+++ b/src/main/java/org/apache/aurora/scheduler/sla/SlaGroup.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/sla/SlaModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/sla/SlaModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/sla/SlaUtil.java
+++ b/src/main/java/org/apache/aurora/scheduler/sla/SlaUtil.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/state/LockManager.java
+++ b/src/main/java/org/apache/aurora/scheduler/state/LockManager.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/state/LockManagerImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/state/LockManagerImpl.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/state/MaintenanceController.java
+++ b/src/main/java/org/apache/aurora/scheduler/state/MaintenanceController.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/state/SchedulerCore.java
+++ b/src/main/java/org/apache/aurora/scheduler/state/SchedulerCore.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/state/SchedulerCoreImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/state/SchedulerCoreImpl.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/state/SideEffect.java
+++ b/src/main/java/org/apache/aurora/scheduler/state/SideEffect.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/state/StateManager.java
+++ b/src/main/java/org/apache/aurora/scheduler/state/StateManager.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/state/StateManagerImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/state/StateManagerImpl.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/state/StateModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/state/StateModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/state/TaskAssigner.java
+++ b/src/main/java/org/apache/aurora/scheduler/state/TaskAssigner.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/state/TaskStateMachine.java
+++ b/src/main/java/org/apache/aurora/scheduler/state/TaskStateMachine.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/state/TransitionResult.java
+++ b/src/main/java/org/apache/aurora/scheduler/state/TransitionResult.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/state/UUIDGenerator.java
+++ b/src/main/java/org/apache/aurora/scheduler/state/UUIDGenerator.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/stats/AsyncStatsModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/stats/AsyncStatsModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/stats/CachedCounters.java
+++ b/src/main/java/org/apache/aurora/scheduler/stats/CachedCounters.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/stats/ResourceCounter.java
+++ b/src/main/java/org/apache/aurora/scheduler/stats/ResourceCounter.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/stats/SlotSizeCounter.java
+++ b/src/main/java/org/apache/aurora/scheduler/stats/SlotSizeCounter.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/stats/TaskStatCalculator.java
+++ b/src/main/java/org/apache/aurora/scheduler/stats/TaskStatCalculator.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/AttributeStore.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/AttributeStore.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/CallOrderEnforcingStorage.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/CallOrderEnforcingStorage.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/DistributedSnapshotStore.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/DistributedSnapshotStore.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/ForwardingStore.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/ForwardingStore.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/JobStore.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/JobStore.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/LockStore.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/LockStore.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/QuotaStore.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/QuotaStore.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/ReadWriteLockManager.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/ReadWriteLockManager.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/SchedulerStore.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/SchedulerStore.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/SnapshotStore.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/SnapshotStore.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/Storage.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/Storage.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/StorageBackfill.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/StorageBackfill.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/TaskStore.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/TaskStore.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/backup/BackupModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/backup/BackupModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/backup/Recovery.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/backup/Recovery.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/backup/StorageBackup.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/backup/StorageBackup.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/backup/TemporaryStorage.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/backup/TemporaryStorage.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/log/Entries.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/log/Entries.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/log/LogManager.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/log/LogManager.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/log/LogStorage.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/log/LogStorage.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/log/LogStorageModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/log/LogStorageModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/log/SnapshotStoreImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/log/SnapshotStoreImpl.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/log/WriteAheadStorage.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/log/WriteAheadStorage.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/log/testing/LogOpMatcher.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/log/testing/LogOpMatcher.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/mem/Interner.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/mem/Interner.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/mem/MemAttributeStore.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/mem/MemAttributeStore.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/mem/MemJobStore.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/mem/MemJobStore.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/mem/MemLockStore.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/mem/MemLockStore.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/mem/MemQuotaStore.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/mem/MemQuotaStore.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/mem/MemSchedulerStore.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/mem/MemSchedulerStore.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/mem/MemStorage.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/mem/MemStorage.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/mem/MemStorageModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/mem/MemStorageModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/mem/MemTaskStore.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/mem/MemTaskStore.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/mem/Util.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/mem/Util.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/storage/testing/StorageTestUtil.java
+++ b/src/main/java/org/apache/aurora/scheduler/storage/testing/StorageTestUtil.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/thrift/SchedulerAPIServlet.java
+++ b/src/main/java/org/apache/aurora/scheduler/thrift/SchedulerAPIServlet.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/thrift/SchedulerThriftInterface.java
+++ b/src/main/java/org/apache/aurora/scheduler/thrift/SchedulerThriftInterface.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/thrift/ThriftConfiguration.java
+++ b/src/main/java/org/apache/aurora/scheduler/thrift/ThriftConfiguration.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/thrift/ThriftModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/thrift/ThriftModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/thrift/aop/AopModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/thrift/aop/AopModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/thrift/aop/FeatureToggleInterceptor.java
+++ b/src/main/java/org/apache/aurora/scheduler/thrift/aop/FeatureToggleInterceptor.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/thrift/aop/Interceptors.java
+++ b/src/main/java/org/apache/aurora/scheduler/thrift/aop/Interceptors.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/thrift/aop/LoggingInterceptor.java
+++ b/src/main/java/org/apache/aurora/scheduler/thrift/aop/LoggingInterceptor.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/thrift/aop/ServerInfoInterceptor.java
+++ b/src/main/java/org/apache/aurora/scheduler/thrift/aop/ServerInfoInterceptor.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/thrift/aop/ThriftStatsExporterInterceptor.java
+++ b/src/main/java/org/apache/aurora/scheduler/thrift/aop/ThriftStatsExporterInterceptor.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/thrift/aop/UserCapabilityInterceptor.java
+++ b/src/main/java/org/apache/aurora/scheduler/thrift/aop/UserCapabilityInterceptor.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/thrift/auth/DecoratedThrift.java
+++ b/src/main/java/org/apache/aurora/scheduler/thrift/auth/DecoratedThrift.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/thrift/auth/Requires.java
+++ b/src/main/java/org/apache/aurora/scheduler/thrift/auth/Requires.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/aurora/scheduler/thrift/auth/ThriftAuthModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/thrift/auth/ThriftAuthModule.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/python/apache/__init__.py
+++ b/src/main/python/apache/__init__.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/__init__.py
+++ b/src/main/python/apache/aurora/__init__.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/admin/BUILD
+++ b/src/main/python/apache/aurora/admin/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/admin/host_maintenance.py
+++ b/src/main/python/apache/aurora/admin/host_maintenance.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/BUILD
+++ b/src/main/python/apache/aurora/client/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/__init__.py
+++ b/src/main/python/apache/aurora/client/__init__.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/api/BUILD
+++ b/src/main/python/apache/aurora/client/api/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/api/__init__.py
+++ b/src/main/python/apache/aurora/client/api/__init__.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/api/command_runner.py
+++ b/src/main/python/apache/aurora/client/api/command_runner.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/api/disambiguator.py
+++ b/src/main/python/apache/aurora/client/api/disambiguator.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/api/health_check.py
+++ b/src/main/python/apache/aurora/client/api/health_check.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/api/instance_watcher.py
+++ b/src/main/python/apache/aurora/client/api/instance_watcher.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/api/job_monitor.py
+++ b/src/main/python/apache/aurora/client/api/job_monitor.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/api/quota_check.py
+++ b/src/main/python/apache/aurora/client/api/quota_check.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/api/restarter.py
+++ b/src/main/python/apache/aurora/client/api/restarter.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/api/scheduler_client.py
+++ b/src/main/python/apache/aurora/client/api/scheduler_client.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/api/sla.py
+++ b/src/main/python/apache/aurora/client/api/sla.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/api/updater.py
+++ b/src/main/python/apache/aurora/client/api/updater.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/api/updater_util.py
+++ b/src/main/python/apache/aurora/client/api/updater_util.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/base.py
+++ b/src/main/python/apache/aurora/client/base.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/bin/BUILD
+++ b/src/main/python/apache/aurora/client/bin/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/bin/aurora_admin.py
+++ b/src/main/python/apache/aurora/client/bin/aurora_admin.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/bin/aurora_client.py
+++ b/src/main/python/apache/aurora/client/bin/aurora_client.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/binding_helper.py
+++ b/src/main/python/apache/aurora/client/binding_helper.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/cli/BUILD
+++ b/src/main/python/apache/aurora/client/cli/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/cli/__init__.py
+++ b/src/main/python/apache/aurora/client/cli/__init__.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/cli/bridge.py
+++ b/src/main/python/apache/aurora/client/cli/bridge.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/cli/client.py
+++ b/src/main/python/apache/aurora/client/cli/client.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/cli/command_hooks.py
+++ b/src/main/python/apache/aurora/client/cli/command_hooks.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/cli/config.py
+++ b/src/main/python/apache/aurora/client/cli/config.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/cli/context.py
+++ b/src/main/python/apache/aurora/client/cli/context.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/cli/jobs.py
+++ b/src/main/python/apache/aurora/client/cli/jobs.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/cli/options.py
+++ b/src/main/python/apache/aurora/client/cli/options.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/cli/quota.py
+++ b/src/main/python/apache/aurora/client/cli/quota.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/cli/sla.py
+++ b/src/main/python/apache/aurora/client/cli/sla.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/cli/task.py
+++ b/src/main/python/apache/aurora/client/cli/task.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/commands/BUILD
+++ b/src/main/python/apache/aurora/client/commands/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/commands/admin.py
+++ b/src/main/python/apache/aurora/client/commands/admin.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/commands/core.py
+++ b/src/main/python/apache/aurora/client/commands/core.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/commands/help.py
+++ b/src/main/python/apache/aurora/client/commands/help.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/commands/maintenance.py
+++ b/src/main/python/apache/aurora/client/commands/maintenance.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/commands/run.py
+++ b/src/main/python/apache/aurora/client/commands/run.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/commands/ssh.py
+++ b/src/main/python/apache/aurora/client/commands/ssh.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/config.py
+++ b/src/main/python/apache/aurora/client/config.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/factory.py
+++ b/src/main/python/apache/aurora/client/factory.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/hooks/BUILD
+++ b/src/main/python/apache/aurora/client/hooks/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/hooks/__init__.py
+++ b/src/main/python/apache/aurora/client/hooks/__init__.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/hooks/hooked_api.py
+++ b/src/main/python/apache/aurora/client/hooks/hooked_api.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/client/options.py
+++ b/src/main/python/apache/aurora/client/options.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/common/BUILD
+++ b/src/main/python/apache/aurora/common/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/common/aurora_job_key.py
+++ b/src/main/python/apache/aurora/common/aurora_job_key.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/common/auth/BUILD
+++ b/src/main/python/apache/aurora/common/auth/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/common/auth/__init__.py
+++ b/src/main/python/apache/aurora/common/auth/__init__.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/common/auth/auth_module.py
+++ b/src/main/python/apache/aurora/common/auth/auth_module.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/common/auth/auth_module_manager.py
+++ b/src/main/python/apache/aurora/common/auth/auth_module_manager.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/common/cluster.py
+++ b/src/main/python/apache/aurora/common/cluster.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/common/cluster_option.py
+++ b/src/main/python/apache/aurora/common/cluster_option.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/common/clusters.py
+++ b/src/main/python/apache/aurora/common/clusters.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/common/http_signaler.py
+++ b/src/main/python/apache/aurora/common/http_signaler.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/common/shellify.py
+++ b/src/main/python/apache/aurora/common/shellify.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/config/BUILD
+++ b/src/main/python/apache/aurora/config/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/config/__init__.py
+++ b/src/main/python/apache/aurora/config/__init__.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/config/loader.py
+++ b/src/main/python/apache/aurora/config/loader.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/config/port_resolver.py
+++ b/src/main/python/apache/aurora/config/port_resolver.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/config/recipes.py
+++ b/src/main/python/apache/aurora/config/recipes.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/config/repl.py
+++ b/src/main/python/apache/aurora/config/repl.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/config/schema/BUILD
+++ b/src/main/python/apache/aurora/config/schema/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/config/schema/base.py
+++ b/src/main/python/apache/aurora/config/schema/base.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/config/thrift.py
+++ b/src/main/python/apache/aurora/config/thrift.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/BUILD
+++ b/src/main/python/apache/aurora/executor/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/__init__.py
+++ b/src/main/python/apache/aurora/executor/__init__.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/aurora_executor.py
+++ b/src/main/python/apache/aurora/executor/aurora_executor.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/bin/BUILD
+++ b/src/main/python/apache/aurora/executor/bin/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/bin/gc_executor_main.py
+++ b/src/main/python/apache/aurora/executor/bin/gc_executor_main.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/bin/thermos_executor_main.py
+++ b/src/main/python/apache/aurora/executor/bin/thermos_executor_main.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/bin/thermos_runner_main.py
+++ b/src/main/python/apache/aurora/executor/bin/thermos_runner_main.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/common/BUILD
+++ b/src/main/python/apache/aurora/executor/common/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/common/executor_timeout.py
+++ b/src/main/python/apache/aurora/executor/common/executor_timeout.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/common/health_checker.py
+++ b/src/main/python/apache/aurora/executor/common/health_checker.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/common/kill_manager.py
+++ b/src/main/python/apache/aurora/executor/common/kill_manager.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/common/sandbox.py
+++ b/src/main/python/apache/aurora/executor/common/sandbox.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/common/status_checker.py
+++ b/src/main/python/apache/aurora/executor/common/status_checker.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/common/task_info.py
+++ b/src/main/python/apache/aurora/executor/common/task_info.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/common/task_runner.py
+++ b/src/main/python/apache/aurora/executor/common/task_runner.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/executor_base.py
+++ b/src/main/python/apache/aurora/executor/executor_base.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/executor_detector.py
+++ b/src/main/python/apache/aurora/executor/executor_detector.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/executor_vars.py
+++ b/src/main/python/apache/aurora/executor/executor_vars.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/gc_executor.py
+++ b/src/main/python/apache/aurora/executor/gc_executor.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/status_manager.py
+++ b/src/main/python/apache/aurora/executor/status_manager.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/thermos_runner.py
+++ b/src/main/python/apache/aurora/executor/thermos_runner.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/executor/thermos_task_runner.py
+++ b/src/main/python/apache/aurora/executor/thermos_task_runner.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/tools/java/organize_imports.py
+++ b/src/main/python/apache/aurora/tools/java/organize_imports.py
@@ -1,6 +1,5 @@
 #!/bin/env python
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/aurora/tools/java/thrift_wrapper_codegen.py
+++ b/src/main/python/apache/aurora/tools/java/thrift_wrapper_codegen.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -128,7 +127,6 @@ STRUCT_COLLECTION_FIELD_ASSIGNMENT = '''this.%(field)s = !wrapped.%(isset)s()
 PACKAGE_NAME = 'org.apache.aurora.scheduler.storage.entities'
 
 CLASS_TEMPLATE = '''/*
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/BUILD
+++ b/src/main/python/apache/thermos/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/__init__.py
+++ b/src/main/python/apache/thermos/__init__.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/bin/BUILD
+++ b/src/main/python/apache/thermos/bin/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/bin/thermos.py
+++ b/src/main/python/apache/thermos/bin/thermos.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/bin/thermos_ckpt.py
+++ b/src/main/python/apache/thermos/bin/thermos_ckpt.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/common/BUILD
+++ b/src/main/python/apache/thermos/common/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/common/ckpt.py
+++ b/src/main/python/apache/thermos/common/ckpt.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/common/options.py
+++ b/src/main/python/apache/thermos/common/options.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/common/path.py
+++ b/src/main/python/apache/thermos/common/path.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/common/planner.py
+++ b/src/main/python/apache/thermos/common/planner.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/config/BUILD
+++ b/src/main/python/apache/thermos/config/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/config/bin/config_load.py
+++ b/src/main/python/apache/thermos/config/bin/config_load.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/config/bin/config_repl.py
+++ b/src/main/python/apache/thermos/config/bin/config_repl.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/config/loader.py
+++ b/src/main/python/apache/thermos/config/loader.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/config/schema.py
+++ b/src/main/python/apache/thermos/config/schema.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/config/schema_base.py
+++ b/src/main/python/apache/thermos/config/schema_base.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/config/schema_helpers.py
+++ b/src/main/python/apache/thermos/config/schema_helpers.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/core/BUILD
+++ b/src/main/python/apache/thermos/core/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/core/__init__.py
+++ b/src/main/python/apache/thermos/core/__init__.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/core/helper.py
+++ b/src/main/python/apache/thermos/core/helper.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/core/inspector.py
+++ b/src/main/python/apache/thermos/core/inspector.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/core/muxer.py
+++ b/src/main/python/apache/thermos/core/muxer.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/core/process.py
+++ b/src/main/python/apache/thermos/core/process.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/core/runner.py
+++ b/src/main/python/apache/thermos/core/runner.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/monitoring/BUILD
+++ b/src/main/python/apache/thermos/monitoring/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/monitoring/detector.py
+++ b/src/main/python/apache/thermos/monitoring/detector.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/monitoring/disk.py
+++ b/src/main/python/apache/thermos/monitoring/disk.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/monitoring/garbage.py
+++ b/src/main/python/apache/thermos/monitoring/garbage.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/monitoring/monitor.py
+++ b/src/main/python/apache/thermos/monitoring/monitor.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/monitoring/process.py
+++ b/src/main/python/apache/thermos/monitoring/process.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/monitoring/process_collector_psutil.py
+++ b/src/main/python/apache/thermos/monitoring/process_collector_psutil.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/monitoring/resource.py
+++ b/src/main/python/apache/thermos/monitoring/resource.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/observer/BUILD
+++ b/src/main/python/apache/thermos/observer/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/observer/bin/BUILD
+++ b/src/main/python/apache/thermos/observer/bin/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/observer/bin/thermos_observer.py
+++ b/src/main/python/apache/thermos/observer/bin/thermos_observer.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/observer/http/BUILD
+++ b/src/main/python/apache/thermos/observer/http/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/observer/http/assets/jquery.pailer.js
+++ b/src/main/python/apache/thermos/observer/http/assets/jquery.pailer.js
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/observer/http/assets/observer.js
+++ b/src/main/python/apache/thermos/observer/http/assets/observer.js
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/observer/http/file_browser.py
+++ b/src/main/python/apache/thermos/observer/http/file_browser.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/observer/http/http_observer.py
+++ b/src/main/python/apache/thermos/observer/http/http_observer.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/observer/http/json.py
+++ b/src/main/python/apache/thermos/observer/http/json.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/observer/http/static_assets.py
+++ b/src/main/python/apache/thermos/observer/http/static_assets.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/observer/http/templating.py
+++ b/src/main/python/apache/thermos/observer/http/templating.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/observer/observed_task.py
+++ b/src/main/python/apache/thermos/observer/observed_task.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/observer/task_observer.py
+++ b/src/main/python/apache/thermos/observer/task_observer.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/testing/BUILD
+++ b/src/main/python/apache/thermos/testing/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/python/apache/thermos/testing/runner.py
+++ b/src/main/python/apache/thermos/testing/runner.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/resources/org/apache/aurora/scheduler/http/ui/js/app.js
+++ b/src/main/resources/org/apache/aurora/scheduler/http/ui/js/app.js
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/org/apache/aurora/scheduler/http/ui/js/controllers.js
+++ b/src/main/resources/org/apache/aurora/scheduler/http/ui/js/controllers.js
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/org/apache/aurora/scheduler/http/ui/js/directives.js
+++ b/src/main/resources/org/apache/aurora/scheduler/http/ui/js/directives.js
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/org/apache/aurora/scheduler/http/ui/js/filters.js
+++ b/src/main/resources/org/apache/aurora/scheduler/http/ui/js/filters.js
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/org/apache/aurora/scheduler/http/ui/js/services.js
+++ b/src/main/resources/org/apache/aurora/scheduler/http/ui/js/services.js
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/thrift/org/apache/aurora/gen/BUILD
+++ b/src/main/thrift/org/apache/aurora/gen/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/thrift/org/apache/aurora/gen/api.thrift
+++ b/src/main/thrift/org/apache/aurora/gen/api.thrift
@@ -1,5 +1,4 @@
 /*
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/thrift/org/apache/aurora/gen/internal_rpc.thrift
+++ b/src/main/thrift/org/apache/aurora/gen/internal_rpc.thrift
@@ -1,5 +1,4 @@
 /*
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/thrift/org/apache/aurora/gen/storage.thrift
+++ b/src/main/thrift/org/apache/aurora/gen/storage.thrift
@@ -1,5 +1,4 @@
 /*
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/thrift/org/apache/aurora/gen/storage_local.thrift
+++ b/src/main/thrift/org/apache/aurora/gen/storage_local.thrift
@@ -1,5 +1,4 @@
 /*
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/thrift/org/apache/aurora/gen/test.thrift
+++ b/src/main/thrift/org/apache/aurora/gen/test.thrift
@@ -1,5 +1,4 @@
 /*
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/thrift/org/apache/thermos/BUILD
+++ b/src/main/thrift/org/apache/thermos/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/thrift/org/apache/thermos/thermos_internal.thrift
+++ b/src/main/thrift/org/apache/thermos/thermos_internal.thrift
@@ -1,5 +1,4 @@
 /*
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/GuiceUtilsTest.java
+++ b/src/test/java/org/apache/aurora/GuiceUtilsTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/codec/ThriftBinaryCodecTest.java
+++ b/src/test/java/org/apache/aurora/codec/ThriftBinaryCodecTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/DriverFactoryImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/DriverFactoryImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/DriverTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/DriverTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/MesosSchedulerImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/MesosSchedulerImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/MesosTaskFactoryImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/MesosTaskFactoryImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/SchedulerLifecycleTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/SchedulerLifecycleTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/TaskVarsTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/TaskVarsTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/UserTaskLauncherTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/UserTaskLauncherTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/app/SchedulerIT.java
+++ b/src/test/java/org/apache/aurora/scheduler/app/SchedulerIT.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/async/GcExecutorLauncherTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/async/GcExecutorLauncherTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/async/HistoryPrunerTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/async/HistoryPrunerTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/async/OfferQueueImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/async/OfferQueueImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/async/Offers.java
+++ b/src/test/java/org/apache/aurora/scheduler/async/Offers.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/async/PreemptorImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/async/PreemptorImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/async/RescheduleCalculatorImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/async/RescheduleCalculatorImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/async/TaskGroupsTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/async/TaskGroupsTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/async/TaskSchedulerImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/async/TaskSchedulerImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/async/TaskSchedulerTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/async/TaskSchedulerTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/async/TaskThrottlerTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/async/TaskThrottlerTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/async/TaskTimeoutTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/async/TaskTimeoutTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/base/AsyncUtilTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/base/AsyncUtilTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/base/CommandUtilTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/base/CommandUtilTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/base/JobsTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/base/JobsTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/base/NumbersTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/base/NumbersTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/base/TaskTestUtil.java
+++ b/src/test/java/org/apache/aurora/scheduler/base/TaskTestUtil.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/base/TasksTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/base/TasksTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/configuration/ConfigurationManagerTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/configuration/ConfigurationManagerTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/configuration/ResourcesTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/configuration/ResourcesTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/cron/CrontabEntryTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/cron/CrontabEntryTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/cron/ExpectedPrediction.java
+++ b/src/test/java/org/apache/aurora/scheduler/cron/ExpectedPrediction.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/cron/quartz/AuroraCronJobTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/cron/quartz/AuroraCronJobTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/cron/quartz/CronIT.java
+++ b/src/test/java/org/apache/aurora/scheduler/cron/quartz/CronIT.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/cron/quartz/CronJobManagerImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/cron/quartz/CronJobManagerImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/cron/quartz/CronPredictorImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/cron/quartz/CronPredictorImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/cron/quartz/QuartzTestUtil.java
+++ b/src/test/java/org/apache/aurora/scheduler/cron/quartz/QuartzTestUtil.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/events/NotifyingSchedulingFilterTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/events/NotifyingSchedulingFilterTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/filter/AttributeAggregateTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/filter/AttributeAggregateTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/filter/SchedulingFilterImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/filter/SchedulingFilterImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/http/LeaderRedirectTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/http/LeaderRedirectTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/http/MnameTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/http/MnameTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/log/mesos/MesosLogTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/log/mesos/MesosLogTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/log/testing/FileLogTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/log/testing/FileLogTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/metadata/NearestFitTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/metadata/NearestFitTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/quota/QuotaCheckResultTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/quota/QuotaCheckResultTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/quota/QuotaManagerImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/quota/QuotaManagerImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/sla/MetricCalculatorTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/sla/MetricCalculatorTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/sla/SlaAlgorithmTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/sla/SlaAlgorithmTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/sla/SlaModuleTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/sla/SlaModuleTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/sla/SlaTestUtil.java
+++ b/src/test/java/org/apache/aurora/scheduler/sla/SlaTestUtil.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/state/BaseSchedulerCoreImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/state/BaseSchedulerCoreImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/state/LockManagerImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/state/LockManagerImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/state/MaintenanceControllerImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/state/MaintenanceControllerImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/state/PubsubTestUtil.java
+++ b/src/test/java/org/apache/aurora/scheduler/state/PubsubTestUtil.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/state/StateManagerImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/state/StateManagerImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/state/TaskAssignerImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/state/TaskAssignerImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2014 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/state/TaskStateMachineTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/state/TaskStateMachineTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/stats/SlotSizeCounterTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/stats/SlotSizeCounterTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/storage/ReadWriteLockManagerTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/storage/ReadWriteLockManagerTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/storage/backup/RecoveryTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/storage/backup/RecoveryTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/storage/backup/StorageBackupTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/storage/backup/StorageBackupTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/storage/log/LogManagerTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/storage/log/LogManagerTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/storage/log/LogStorageTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/storage/log/LogStorageTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/storage/log/SnapshotStoreImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/storage/log/SnapshotStoreImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/storage/mem/InternerTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/storage/mem/InternerTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/storage/mem/MemJobStoreTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/storage/mem/MemJobStoreTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/storage/mem/MemLockStoreTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/storage/mem/MemLockStoreTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/storage/mem/MemStorageSchedulerCoreImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/storage/mem/MemStorageSchedulerCoreImplTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/storage/mem/MemStorageTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/storage/mem/MemStorageTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/storage/mem/MemTaskStoreTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/storage/mem/MemTaskStoreTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/thrift/SchedulerThriftInterfaceTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/thrift/SchedulerThriftInterfaceTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/thrift/ThriftIT.java
+++ b/src/test/java/org/apache/aurora/scheduler/thrift/ThriftIT.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/thrift/aop/AopModuleTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/thrift/aop/AopModuleTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/thrift/aop/FeatureToggleInterceptorTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/thrift/aop/FeatureToggleInterceptorTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/thrift/aop/ForwardingThrift.java
+++ b/src/test/java/org/apache/aurora/scheduler/thrift/aop/ForwardingThrift.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/thrift/aop/MockDecoratedThrift.java
+++ b/src/test/java/org/apache/aurora/scheduler/thrift/aop/MockDecoratedThrift.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/thrift/aop/ServerInfoInterceptorTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/thrift/aop/ServerInfoInterceptorTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/aurora/scheduler/thrift/aop/ThriftStatsExporterInterceptorTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/thrift/aop/ThriftStatsExporterInterceptorTest.java
@@ -1,5 +1,4 @@
 /**
- * Copyright 2013 Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/python/BUILD
+++ b/src/test/python/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/BUILD
+++ b/src/test/python/apache/aurora/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/admin/BUILD
+++ b/src/test/python/apache/aurora/admin/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/admin/test_host_maintenance.py
+++ b/src/test/python/apache/aurora/admin/test_host_maintenance.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/BUILD
+++ b/src/test/python/apache/aurora/client/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/api/BUILD
+++ b/src/test/python/apache/aurora/client/api/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/api/test_disambiguator.py
+++ b/src/test/python/apache/aurora/client/api/test_disambiguator.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/api/test_health_check.py
+++ b/src/test/python/apache/aurora/client/api/test_health_check.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/api/test_instance_watcher.py
+++ b/src/test/python/apache/aurora/client/api/test_instance_watcher.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/api/test_job_monitor.py
+++ b/src/test/python/apache/aurora/client/api/test_job_monitor.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/api/test_quota_check.py
+++ b/src/test/python/apache/aurora/client/api/test_quota_check.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/api/test_restarter.py
+++ b/src/test/python/apache/aurora/client/api/test_restarter.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/api/test_scheduler_client.py
+++ b/src/test/python/apache/aurora/client/api/test_scheduler_client.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/api/test_sla.py
+++ b/src/test/python/apache/aurora/client/api/test_sla.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/api/test_updater.py
+++ b/src/test/python/apache/aurora/client/api/test_updater.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/BUILD
+++ b/src/test/python/apache/aurora/client/cli/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_bridge.py
+++ b/src/test/python/apache/aurora/client/cli/test_bridge.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_cancel_update.py
+++ b/src/test/python/apache/aurora/client/cli/test_cancel_update.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_command_hooks.py
+++ b/src/test/python/apache/aurora/client/cli/test_command_hooks.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_config_noun.py
+++ b/src/test/python/apache/aurora/client/cli/test_config_noun.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_create.py
+++ b/src/test/python/apache/aurora/client/cli/test_create.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_diff.py
+++ b/src/test/python/apache/aurora/client/cli/test_diff.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_help.py
+++ b/src/test/python/apache/aurora/client/cli/test_help.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_kill.py
+++ b/src/test/python/apache/aurora/client/cli/test_kill.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_logging.py
+++ b/src/test/python/apache/aurora/client/cli/test_logging.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_open.py
+++ b/src/test/python/apache/aurora/client/cli/test_open.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_plugins.py
+++ b/src/test/python/apache/aurora/client/cli/test_plugins.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_quota.py
+++ b/src/test/python/apache/aurora/client/cli/test_quota.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_restart.py
+++ b/src/test/python/apache/aurora/client/cli/test_restart.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_sla.py
+++ b/src/test/python/apache/aurora/client/cli/test_sla.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_status.py
+++ b/src/test/python/apache/aurora/client/cli/test_status.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_task_run.py
+++ b/src/test/python/apache/aurora/client/cli/test_task_run.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/test_update.py
+++ b/src/test/python/apache/aurora/client/cli/test_update.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/cli/util.py
+++ b/src/test/python/apache/aurora/client/cli/util.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/commands/BUILD
+++ b/src/test/python/apache/aurora/client/commands/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/commands/test_admin_sla.py
+++ b/src/test/python/apache/aurora/client/commands/test_admin_sla.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/commands/test_cancel_update.py
+++ b/src/test/python/apache/aurora/client/commands/test_cancel_update.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/commands/test_create.py
+++ b/src/test/python/apache/aurora/client/commands/test_create.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/commands/test_diff.py
+++ b/src/test/python/apache/aurora/client/commands/test_diff.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/commands/test_hooks.py
+++ b/src/test/python/apache/aurora/client/commands/test_hooks.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/commands/test_kill.py
+++ b/src/test/python/apache/aurora/client/commands/test_kill.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/commands/test_listjobs.py
+++ b/src/test/python/apache/aurora/client/commands/test_listjobs.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/commands/test_maintenance.py
+++ b/src/test/python/apache/aurora/client/commands/test_maintenance.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/commands/test_restart.py
+++ b/src/test/python/apache/aurora/client/commands/test_restart.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/commands/test_run.py
+++ b/src/test/python/apache/aurora/client/commands/test_run.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/commands/test_ssh.py
+++ b/src/test/python/apache/aurora/client/commands/test_ssh.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/commands/test_status.py
+++ b/src/test/python/apache/aurora/client/commands/test_status.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/commands/test_update.py
+++ b/src/test/python/apache/aurora/client/commands/test_update.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/commands/util.py
+++ b/src/test/python/apache/aurora/client/commands/util.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/fake_scheduler_proxy.py
+++ b/src/test/python/apache/aurora/client/fake_scheduler_proxy.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/hooks/BUILD
+++ b/src/test/python/apache/aurora/client/hooks/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/hooks/test_hooked_api.py
+++ b/src/test/python/apache/aurora/client/hooks/test_hooked_api.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/hooks/test_non_hooked_api.py
+++ b/src/test/python/apache/aurora/client/hooks/test_non_hooked_api.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/test_binding_helper.py
+++ b/src/test/python/apache/aurora/client/test_binding_helper.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/client/test_config.py
+++ b/src/test/python/apache/aurora/client/test_config.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/common/BUILD
+++ b/src/test/python/apache/aurora/common/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/common/test_aurora_job_key.py
+++ b/src/test/python/apache/aurora/common/test_aurora_job_key.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/common/test_cluster.py
+++ b/src/test/python/apache/aurora/common/test_cluster.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/common/test_cluster_option.py
+++ b/src/test/python/apache/aurora/common/test_cluster_option.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/common/test_clusters.py
+++ b/src/test/python/apache/aurora/common/test_clusters.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/common/test_http_signaler.py
+++ b/src/test/python/apache/aurora/common/test_http_signaler.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/common/test_shellify.py
+++ b/src/test/python/apache/aurora/common/test_shellify.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/config/BUILD
+++ b/src/test/python/apache/aurora/config/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/config/test_base.py
+++ b/src/test/python/apache/aurora/config/test_base.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/config/test_constraint_parsing.py
+++ b/src/test/python/apache/aurora/config/test_constraint_parsing.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/config/test_loader.py
+++ b/src/test/python/apache/aurora/config/test_loader.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/config/test_thrift.py
+++ b/src/test/python/apache/aurora/config/test_thrift.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/executor/BUILD
+++ b/src/test/python/apache/aurora/executor/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/executor/common/BUILD
+++ b/src/test/python/apache/aurora/executor/common/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/executor/common/test_directory_sandbox.py
+++ b/src/test/python/apache/aurora/executor/common/test_directory_sandbox.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/executor/common/test_health_checker.py
+++ b/src/test/python/apache/aurora/executor/common/test_health_checker.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/executor/common/test_status_checker.py
+++ b/src/test/python/apache/aurora/executor/common/test_status_checker.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/executor/common/test_task_info.py
+++ b/src/test/python/apache/aurora/executor/common/test_task_info.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/executor/test_executor_builds.py
+++ b/src/test/python/apache/aurora/executor/test_executor_builds.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/executor/test_executor_detector.py
+++ b/src/test/python/apache/aurora/executor/test_executor_detector.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/executor/test_executor_vars.py
+++ b/src/test/python/apache/aurora/executor/test_executor_vars.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/executor/test_gc_executor.py
+++ b/src/test/python/apache/aurora/executor/test_gc_executor.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/executor/test_thermos_executor.py
+++ b/src/test/python/apache/aurora/executor/test_thermos_executor.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/aurora/executor/test_thermos_task_runner.py
+++ b/src/test/python/apache/aurora/executor/test_thermos_task_runner.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/BUILD
+++ b/src/test/python/apache/thermos/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/bin/BUILD
+++ b/src/test/python/apache/thermos/bin/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/bin/test_thermos.py
+++ b/src/test/python/apache/thermos/bin/test_thermos.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/common/BUILD
+++ b/src/test/python/apache/thermos/common/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/common/test_pathspec.py
+++ b/src/test/python/apache/thermos/common/test_pathspec.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/common/test_planner.py
+++ b/src/test/python/apache/thermos/common/test_planner.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/common/test_task_planner.py
+++ b/src/test/python/apache/thermos/common/test_task_planner.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/config/BUILD
+++ b/src/test/python/apache/thermos/config/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/config/test_schema.py
+++ b/src/test/python/apache/thermos/config/test_schema.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/core/BUILD
+++ b/src/test/python/apache/thermos/core/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/core/test_angry.py
+++ b/src/test/python/apache/thermos/core/test_angry.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/core/test_ephemerals.py
+++ b/src/test/python/apache/thermos/core/test_ephemerals.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/core/test_failing_runner.py
+++ b/src/test/python/apache/thermos/core/test_failing_runner.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/core/test_failure_limit.py
+++ b/src/test/python/apache/thermos/core/test_failure_limit.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/core/test_finalization.py
+++ b/src/test/python/apache/thermos/core/test_finalization.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/core/test_helper.py
+++ b/src/test/python/apache/thermos/core/test_helper.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/core/test_process.py
+++ b/src/test/python/apache/thermos/core/test_process.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/core/test_runner_integration.py
+++ b/src/test/python/apache/thermos/core/test_runner_integration.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/core/test_staged_kill.py
+++ b/src/test/python/apache/thermos/core/test_staged_kill.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/monitoring/BUILD
+++ b/src/test/python/apache/thermos/monitoring/BUILD
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/python/apache/thermos/monitoring/test_disk.py
+++ b/src/test/python/apache/thermos/monitoring/test_disk.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/sh/org/apache/aurora/e2e/http_example.py
+++ b/src/test/sh/org/apache/aurora/e2e/http_example.py
@@ -1,5 +1,4 @@
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/sh/org/apache/aurora/e2e/test_common.sh
+++ b/src/test/sh/org/apache/aurora/e2e/test_common.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -x
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/sh/org/apache/aurora/e2e/test_end_to_end.sh
+++ b/src/test/sh/org/apache/aurora/e2e/test_end_to_end.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/sh/org/apache/aurora/e2e/test_end_to_end_v2.sh
+++ b/src/test/sh/org/apache/aurora/e2e/test_end_to_end_v2.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2014 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/sh/org/apache/aurora/verify_thrift_checksum.sh
+++ b/src/test/sh/org/apache/aurora/verify_thrift_checksum.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2013 Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
https://reviews.apache.org/r/21882/

Some of the files have "Copyright 2013 Apache Software Foundation" in the license header comment.
This is not the right license header per ASF rule [1]
I believe the year is needed for the NOTICE file.
[1] http://www.apache.org/legal/src-headers.html